### PR TITLE
Potential fix for code scanning alert no. 3: Overly permissive regular expression range

### DIFF
--- a/src/components/register/registerForm.tsx
+++ b/src/components/register/registerForm.tsx
@@ -15,7 +15,7 @@ import validator from "validator";
 import axios, { AxiosResponse, AxiosError, AxiosRequestConfig } from "axios";
 import "./registerForm.css";
 
-const USER_REGEX = /^[A-z][A-z0-9-_]{3,23}$/;
+const USER_REGEX = /^[A-Za-z][A-Za-z0-9-_]{3,23}$/;
 const PWD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%]).{8,24}$/;
 
 interface RegisterResponse {


### PR DESCRIPTION
Potential fix for [https://github.com/SupTarr/FrontendImmifit/security/code-scanning/3](https://github.com/SupTarr/FrontendImmifit/security/code-scanning/3)

To fix the issue, the overly permissive range `A-z` should be replaced with two explicit ranges: `A-Z` for uppercase letters and `a-z` for lowercase letters. This ensures that only valid alphabetic characters are matched, avoiding unintended matches with special characters like `[`, `\`, `]`, `^`, `_`, and `` ` ``. The updated regular expression will maintain the intended functionality while improving accuracy.

The change will be made on line 18 of the file `src/components/register/registerForm.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
