### PR TITLE
Potential fix for code scanning alert no. 2: Overly permissive regular expression range

### DIFF
--- a/src/components/login/Logindetail.tsx
+++ b/src/components/login/Logindetail.tsx
@@ -16,7 +16,7 @@ import "./logindetail.css";
 import axios from "../../api/axios";
 import { AxiosError, AxiosResponse, AxiosRequestConfig } from "axios";
 
-const USER_REGEX = /^[A-z][A-z0-9-_]{3,23}$/;
+const USER_REGEX = /^[A-Za-z][A-Za-z0-9-_]{3,23}$/;
 const PWD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%]).{8,24}$/;
 
 interface AuthResponse {


### PR DESCRIPTION
Potential fix for [https://github.com/SupTarr/FrontendImmifit/security/code-scanning/2](https://github.com/SupTarr/FrontendImmifit/security/code-scanning/2)

To fix the issue, the overly permissive range `A-z` should be replaced with the correct range `[A-Za-z]`. This ensures that the regular expression matches only uppercase and lowercase English letters, as intended. The change will be made on line 19 of the file `src/components/login/Logindetail.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
